### PR TITLE
include/oel: Remove the reproducible_build inherit

### DIFF
--- a/conf/distro/include/oel.inc
+++ b/conf/distro/include/oel.inc
@@ -35,9 +35,6 @@ INHERIT += "layerdirs"
 # Do an up front type check to sanity check user configuration
 INHERIT += "typecheck"
 
-# Add reproducible build support
-INHERIT += "reproducible_build"
-
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
 


### PR DESCRIPTION
Remove the inherit for the reproducible_build.class.
This class has been removed in abb0671d commit on the
openembedded-core layer.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>