### PR TITLE
networkmanager: Add option for enable ppp support

### DIFF
--- a/recipes-connectivity/networmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networmanager/networkmanager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG[ppp] = "-Dppp=true -Dpppd_plugin_dir='${libdir}/pppd/2.4.9' -Dpppd=${sbindir}/pppd,-Dppp=false,ppp,ppp"


### PR DESCRIPTION
Add PACKAGECONFIG option for enable ppp support into meson build system.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>