### PR TITLE
python_pyo3: Switch to use RUST_XXX_SYS consistently

### DIFF
--- a/classes/python_pyo3.bbclass
+++ b/classes/python_pyo3.bbclass
@@ -1,0 +1,36 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+#
+# This class helps make sure that Python extensions built with PyO3
+# and setuptools_rust properly set up the environment for cross compilation
+#
+
+inherit cargo python3-dir siteinfo
+
+export PYO3_CROSS="1"
+export PYO3_CROSS_PYTHON_VERSION="${PYTHON_BASEVERSION}"
+export PYO3_CROSS_LIB_DIR="${STAGING_LIBDIR}"
+export CARGO_BUILD_TARGET="${RUST_HOST_SYS}"
+export RUSTFLAGS
+export PYO3_PYTHON="${PYTHON}"
+export PYO3_CONFIG_FILE="${WORKDIR}/pyo3.config"
+
+python_pyo3_do_configure () {
+    cat > ${WORKDIR}/pyo3.config << EOF
+implementation=CPython
+version=${PYTHON_BASEVERSION}
+shared=true
+abi3=false
+lib_name=${PYTHON_DIR}
+lib_dir=${STAGING_LIBDIR}
+pointer_width=${SITEINFO_BITS}
+build_flags=WITH_THREAD
+suppress_build_script_link_lines=false
+EOF
+}
+
+EXPORT_FUNCTIONS do_configure


### PR DESCRIPTION
The code was using a mixture of XXX_SYS and RUST_XXX_SYS. Use RUST_XXX_SYS consistently and add the variables to the global exclsion on signatures as they're reflected in the directory triplets and trying to filter them out the hashes separately is too painful.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>