### PR TITLE
layerdirs.bbclass: Fix addpylib support

### DIFF
--- a/classes/layerdirs.bbclass
+++ b/classes/layerdirs.bbclass
@@ -4,7 +4,7 @@ def save_layerdirs(d):
 
         l = bb.data.init()
         l.setVar('LAYERDIR', layerpath)
-        l = bb.parse.handle(layerconf, l)
+        l = bb.parse.handle(layerconf, l, baseconfig=True)
         l.expandVarref('LAYERDIR')
 
         for layername in (l.getVar('BBFILE_COLLECTIONS', True) or '').split():


### PR DESCRIPTION
bb.parse.handle() won't parse "addpylib" lines unless the baseconfig argument is set to True.

For more details, see:

https://github.com/openembedded/bitbake/commit/afb8478d3853f6edf3669b93588314627d617d6b