### PR TITLE
Convert overrides for new bitbake syntax

### DIFF
--- a/conf/distro/oel-tiny.conf
+++ b/conf/distro/oel-tiny.conf
@@ -37,7 +37,7 @@ DISTRO_NAME = "O.S. Systems Embedded Linux Tiny"
 TCLIBC = "musl"
 DISTROOVERRIDES = "oel:oel-tiny"
 # FIXME: consider adding a new "tiny" feature
-#DISTRO_FEATURES_append = " tiny"
+#DISTRO_FEATURES:append = " tiny"
 
 # Distro config is evaluated after the machine config, so we have to explicitly
 # set the kernel provider to override a machine config.

--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI:append_oel = "\
+SRC_URI:append:oel = "\
     file://setsid.cfg \
     file://resize.cfg \
     file://pidof.cfg \

--- a/recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
+++ b/recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
@@ -1,8 +1,8 @@
 SUMMARY = "Modular psplash to initramfs system"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
-RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_base-utils}"
-RRECOMMENDS_${PN} = "${VIRTUAL-RUNTIME_base-utils-syslog}"
+RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_base-utils}"
+RRECOMMENDS:${PN} = "${VIRTUAL-RUNTIME_base-utils-syslog}"
 
 PR = "r4"
 
@@ -23,6 +23,6 @@ do_install() {
 
 PACKAGES = "initramfs-module-psplash"
 
-SUMMARY_initramfs-module-psplash = "initramfs psplash support"
-RDEPENDS_initramfs-module-psplash = "initramfs-framework-base psplash"
-FILES_initramfs-module-psplash = "/init.d"
+SUMMARY:initramfs-module-psplash = "initramfs psplash support"
+RDEPENDS:initramfs-module-psplash = "initramfs-framework-base psplash"
+FILES:initramfs-module-psplash = "/init.d"

--- a/recipes-core/os-release/os-release.bbappend
+++ b/recipes-core/os-release/os-release.bbappend
@@ -1,4 +1,4 @@
-OS_RELEASE_FIELDS:append_oel = " BUILD_NUMBER"
+OS_RELEASE_FIELDS:append:oel = " BUILD_NUMBER"
 
 # Append build number for development builds
-VERSION:append_oel = "${@' (build %s)' % BUILD_NUMBER if 'BUILD_NUMBER' in d and DISTRO_VERSION.endswith('+devel') else ''}"
+VERSION:append:oel = "${@' (build %s)' % BUILD_NUMBER if 'BUILD_NUMBER' in d and DISTRO_VERSION.endswith('+devel') else ''}"

--- a/recipes-graphics/weston-touch-calibrator-service/weston-touch-calibrator-service.bb
+++ b/recipes-graphics/weston-touch-calibrator-service/weston-touch-calibrator-service.bb
@@ -22,7 +22,7 @@ do_install() {
     install -Dm 0644 ${WORKDIR}/touchscreen.rules ${D}${base_libdir}/udev/rules.d/98-touchscreen.rules
 }
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     weston-init \
     weston-touch-calibrator \
 "


### PR DESCRIPTION
Convert overrides for new bitbake syntax. This commit changes the following files:
    - conf/distro/oel-tiny.conf
    - recipes-core/busybox/busybox_%.bbappend
    - recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
    - recipes-core/os-release/os-release.bbappend
    - recipes-graphics/weston-touch-calibrator-service/weston-touch-calibrator-service.bb

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>