### PR TITLE
easysplash-animation: Change the gstreamer1.0-plugins-base plugins

### DIFF
--- a/recipes-core/easysplash/easysplash-animation-default_2.0.0.bb
+++ b/recipes-core/easysplash/easysplash-animation-default_2.0.0.bb
@@ -28,8 +28,7 @@ RDEPENDS:${PN} += " \
     gstreamer1.0-plugins-bad-kms \
     gstreamer1.0-plugins-bad-camerabin \
     gstreamer1.0-plugins-good-videofilter \
-    gstreamer1.0-plugins-base-videoconvert \
-    gstreamer1.0-plugins-base-videoscale \
+    gstreamer1.0-plugins-base-videoconvertscale \
     gstreamer1.0-plugins-good-deinterlace \
     gstreamer1.0-plugins-good-multifile \
     gstreamer1.0-plugins-base-typefindfunctions \

--- a/recipes-core/easysplash/easysplash-animation-ossystems_2.0.0.bb
+++ b/recipes-core/easysplash/easysplash-animation-ossystems_2.0.0.bb
@@ -26,8 +26,7 @@ RDEPENDS:${PN} += " \
     gstreamer1.0-plugins-bad-kms \
     gstreamer1.0-plugins-bad-camerabin \
     gstreamer1.0-plugins-good-videofilter \
-    gstreamer1.0-plugins-base-videoconvert \
-    gstreamer1.0-plugins-base-videoscale \
+    gstreamer1.0-plugins-base-videoconvertscale \
     gstreamer1.0-plugins-good-deinterlace \
     gstreamer1.0-plugins-good-multifile \
     gstreamer1.0-plugins-base-typefindfunctions \


### PR DESCRIPTION
This commit changes the following gstreamer plugins:

    - gstreamer1.0-plugins-base-videoconvert
    - gstreamer1.0-plugins-base-videoscale
to
    - gstreamer1.0-plugins-base-videoconvertscale

because they were unified in this commit in opemembedded-core:

fb2d28e0315ece6180c87c7047587673024a09f7