### PR TITLE
fix wrong SRC_URI, update LICENSE

### DIFF
--- a/recipes-devtools/telegraf/telegraf_1.14.5.bb
+++ b/recipes-devtools/telegraf/telegraf_1.14.5.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/influxdata/telegraf"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${S}/src/${GO_IMPORT}/LICENSE;md5=4c87a94f9ef84eb3e8c5f0424fef3b9e"
 
-SRC_URI = "https://github.com/influxdata/telegraf;branch=release-1.14"
+SRC_URI = "git://github.com/influxdata/telegraf;protocol=https;branch=release-1.14"
 SRCREV = "e77ce3d11d2b3d2f66e85921142d4927752054b2"
 
 inherit go-mod systemd

--- a/recipes-extended/zram-init/zram-init_git.bb
+++ b/recipes-extended/zram-init/zram-init_git.bb
@@ -1,10 +1,10 @@
 SUMMARY = "A wrapper script for the zram kernel module with interactive and init support"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/README.md;beginline=5;endline=7;md5=1c6f4971407e5a5b1aa502b9badcdf98"
 
 inherit update-rc.d systemd
 
-SRC_URI = "https://github.com/vaeth/zram-init;branch=main"
+SRC_URI = "git://github.com/vaeth/zram-init;protocol=https;branch=main"
 SRCREV = "703f63bd3e595b9b357d74c58db1370b40af250d"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
`SRC_URI` seems to be wrong, nothing gets checkout out and the recipe fails with `zram-init-git-r0 do_populate_lic: QA Issue: zram-init: LIC_FILES_CHKSUM points to an invalid file`.

Changing LICENSE to `GPL-2.0-only` fixes the `WARNING: zram-init-git-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]`