### PR TITLE
Change the S variable assignment

### DIFF
--- a/recipes-browser/cog/cog-init.bb
+++ b/recipes-browser/cog/cog-init.bb
@@ -41,13 +41,13 @@ do_compile[noexec] = "1"
 
 do_install() {
     if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
-        install -Dm 0755 ${WORKDIR}/${PN}.initd ${D}${sysconfdir}/init.d/cog
+        install -Dm 0755 ${UNPACKDIR}/${PN}.initd ${D}${sysconfdir}/init.d/cog
     fi
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
-        install -Dm 0644 ${WORKDIR}/${PN}.service ${D}${systemd_system_unitdir}/cog.service
+        install -Dm 0644 ${UNPACKDIR}/${PN}.service ${D}${systemd_system_unitdir}/cog.service
     fi
 
-    install -Dm 0644 ${WORKDIR}/${PN}.default ${D}${sysconfdir}/default/cog
+    install -Dm 0644 ${UNPACKDIR}/${PN}.default ${D}${sysconfdir}/default/cog
 
     echo ${COG_ENV} >> ${D}${sysconfdir}/default/cog
 

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -14,7 +14,7 @@ EOF
 addtask do_generate_locale_conf after do_compile before do_install
 
 do_install:append() {
-    install -Dm 0644 ${WORKDIR}/profile.d_locale.sh ${D}${sysconfdir}/profile.d/locale.sh
+    install -Dm 0644 ${S}/profile.d_locale.sh ${D}${sysconfdir}/profile.d/locale.sh
 
     if [ "${@d.getVar('DEFAULT_SYSTEM_LOCALE', True)}" != "" ]; then
         install -Dm 0644 ${WORKDIR}/locale.conf ${D}${sysconfdir}/locale.conf

--- a/recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
+++ b/recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
@@ -13,12 +13,10 @@ SRC_URI = " \
     file://psplash-finish \
 "
 
-S = "${WORKDIR}"
-
 do_install() {
     # psplash
-    install -Dm 0755 ${WORKDIR}/psplash ${D}/init.d/11-psplash
-    install -Dm 0755 ${WORKDIR}/psplash-finish ${D}/init.d/98-psplash_finish
+    install -Dm 0755 ${S}/psplash ${D}/init.d/11-psplash
+    install -Dm 0755 ${S}/psplash-finish ${D}/init.d/98-psplash_finish
 }
 
 PACKAGES = "initramfs-module-psplash"

--- a/recipes-core/tiny-init-system/tiny-init-system.bb
+++ b/recipes-core/tiny-init-system/tiny-init-system.bb
@@ -7,14 +7,12 @@ SRC_URI = "\
     file://rc.local.sample \
 "
 
-S = "${WORKDIR}"
-
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
 do_install() {
-    install -m 0755 ${WORKDIR}/init ${D}
-    install -Dm 0755 ${WORKDIR}/rc.local.sample ${D}${sysconfdir}/rc.local.sample
+    install -m 0755 ${S}/init ${D}
+    install -Dm 0755 ${S}/rc.local.sample ${D}${sysconfdir}/rc.local.sample
 }
 
 FILES:${PN} = "/init ${sysconfdir}/rc.local.sample"


### PR DESCRIPTION
This commit changes the S variable assignment because the assignment of S variable to WORKDIR was considered unsafe after this commit on openembedded-core:

    32cba1cc916ad530c5e6630a927e74ca6f06289b
    Author: Richard Purdie <richard.purdie@linuxfoundation.org>
    Date:   Thu Apr 25 17:00:20 2024 +0100

    insane: Error for S == WORKDIR

    Where a recipe uses WORKDIR as S, exit with a fatal error since the
    code is no longer safe for this layout.

Also: This commit changes the following files:
    - recipes-browser/cog/cog-init.bb
    - recipes-core/base-files/base-files_%.bbappend
    - recipes-core/initrdscripts/initramfs-framework-psplash_1.0.bb
    - recipes-core/tiny-init-system/tiny-init-system.bb