### PR TITLE
distro/oel: Remove the TCLIBCAPPEND variable from distro

### DIFF
--- a/conf/distro/include/oel.inc
+++ b/conf/distro/include/oel.inc
@@ -107,9 +107,6 @@ QEMU_TARGETS ?= "arm aarch64 i386 x86_64 mips mipsel mips64 mips64el ppc ppc64 p
 # Preferred kernel version for QEMU based machines
 PREFERRED_VERSION_linux-yocto ?= "6.1%"
 
-# We avoid appending TCLIBC name on the TMPDIR
-TCLIBCAPPEND = ""
-
 ####
 #### Inherits
 ####

--- a/conf/distro/oel-tiny.conf
+++ b/conf/distro/oel-tiny.conf
@@ -49,9 +49,6 @@ PREFERRED_VERSION_linux-yocto-tiny ?= "4.9%"
 # Drop kernel-module-af-packet from RRECOMMENDS
 OEL_TINY_DEFAULT_EXTRA_RRECOMMENDS = ""
 
-# FIXME: what should we do with this?
-TCLIBCAPPEND = ""
-
 # Disable wide char support for ncurses as we don't include it in
 # in the LIBC features below.
 # Leave native enable to avoid build failures


### PR DESCRIPTION
Since openembedded-core commit:

992ba784c168710328749fd61a0e2869df519dea

This variable is no longer used.