### PR TITLE
conf/distro: Bump kernel version to 6.18

### DIFF
--- a/conf/distro/include/oel.inc
+++ b/conf/distro/include/oel.inc
@@ -1,4 +1,4 @@
-DISTRO_VERSION = "24.04-snapshot-${DATE}"
+DISTRO_VERSION = "26.04-snapshot-${DATE}"
 
 SDK_VENDOR = "-oelsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
@@ -54,6 +54,8 @@ SANITY_TESTED_DISTROS ?= " \
     ubuntu-16.04 \n \
     ubuntu-18.04 \n \
     ubuntu-20.04 \n \
+    ubuntu-22.04 \n \
+    ubuntu-24.04 \n \
     fedora-31 \n \
     fedora-32 \n \
     fedora-33 \n \
@@ -105,7 +107,7 @@ BBFILE_PRIORITY_openembedded-layer = "1"
 QEMU_TARGETS ?= "arm aarch64 i386 x86_64 mips mipsel mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 sh4"
 
 # Preferred kernel version for QEMU based machines
-PREFERRED_VERSION_linux-yocto ?= "6.6%"
+PREFERRED_VERSION_linux-yocto ?= "6.18%"
 
 ####
 #### Inherits
@@ -113,7 +115,6 @@ PREFERRED_VERSION_linux-yocto ?= "6.6%"
 
 # Remove .la files for packages
 INHERIT += "remove-libtool"
-
 # We want information about image contents
 INHERIT += "buildhistory"
 BUILDHISTORY_DIR ?= "${TOPDIR}/buildhistory"

--- a/conf/distro/oel-tiny.conf
+++ b/conf/distro/oel-tiny.conf
@@ -42,7 +42,7 @@ DISTROOVERRIDES = "oel:oel-tiny"
 # Distro config is evaluated after the machine config, so we have to explicitly
 # set the kernel provider to override a machine config.
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-tiny"
-PREFERRED_VERSION_linux-yocto-tiny ?= "4.9%"
+PREFERRED_VERSION_linux-yocto-tiny ?= "6.18%"
 
 # We can use packagegroup-core-boot, but in the future we may need a new packagegroup-core-tiny
 #OEL_TINY_DEFAULT_EXTRA_RDEPENDS += "packagegroup-core-boot"
@@ -77,7 +77,7 @@ DISTRO_FEATURES = " \
 "
 
 # Enable LFS - see bug YOCTO #5865
-DISTRO_FEATURES:append_libc-uclibc = " largefile"
+DISTRO_FEATURES:append:libc-uclibc = " largefile"
 DISTRO_FEATURES:append:libc-musl = " largefile"
 
 DISTRO_FEATURES:class-native = "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${OEL_DEFAULT_DISTRO_FEATURES}"


### PR DESCRIPTION
conf/distro/include/oel.inc: Bump kernel version to 6.18 to have the latest features of the LTS

conf/distro/oel-tiny.conf: Bump the version of the kernel of oel-tiny to follow oel