### PR TITLE
README: Update layer documentation and add security policy

### DIFF
--- a/README
+++ b/README
@@ -14,14 +14,19 @@ revision: HEAD
 Contributing
 ------------
 
-To contribute to this layer you should submit the patches for review
-to our server at https://code.ossystems.com.br
+To contribute to this layer you should submit the pull requests
+on GitHub at https://github.com/OSSystemsEmbeddedLinux/meta-ossystems-base
 
 Please refer to:
-http://openembedded.org/wiki/Commit_Patch_Message_Guidelines
+https://docs.yoctoproject.org/contributor-guide/
 
 for some useful guidelines to be followed when submitting patches.
 
 Source code:
 
-    https://code.ossystems.com.br/gitweb?p=meta-ossystems-base.git
+    https://github.com/OSSystemsEmbeddedLinux/meta-ossystems-base
+
+Maintainer
+----------
+
+Otavio Salvador <otavio.salvador@ossystems.com.br>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+How to Report a Potential Vulnerability?
+========================================
+
+Confirmed or potential security vulnerabilities in the meta-ossystems-base layer should
+be submitted directly via the
+[Issues](https://github.com/OSSystemsEmbeddedLinux/meta-ossystems-base/issues) page.
+
+If you are dealing with a not-yet released or urgent issue, please send a
+message to the maintainer listed in the [README](README). Include as
+many details as possible:
+  - the layer or software module affected
+  - the recipe and its version
+  - any example code, if available
+
+Branches maintained with security fixes
+---------------------------------------
+
+See https://wiki.yoctoproject.org/wiki/Releases for the list of current
+releases. We only accept patches for the LTS releases and the master branch.


### PR DESCRIPTION
Update the layer documentation to use current project links and add the
  maintainer information.

  This also adds SECURITY.md with the vulnerability reporting process for the
  layer, including the public GitHub issue flow and direct maintainer contact for
  urgent or unreleased issues.

  Changes included:
  - Update README contribution and source links to GitHub.
  - Replace the old OpenEmbedded wiki link with the Yocto Project Contributor Guide.
  - Add maintainer information with email address.
  - Add SECURITY.md with vulnerability reporting and maintained branch policy.