### PR TITLE
conf/layer.conf: Add layer validation fixes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "ossystems-base"
 BBFILE_PATTERN_ossystems-base := "^${LAYERDIR}/"
 BBFILE_PRIORITY_ossystems-base = "8"
+LAYERDEPENDS_ossystems-base = "core"
 
 addpylib ${LAYERDIR}/lib ossystems
 

--- a/recipes-graphics/weston-touch-calibrator-service/weston-touch-calibrator-service_1.0.bb
+++ b/recipes-graphics/weston-touch-calibrator-service/weston-touch-calibrator-service_1.0.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
 
 inherit systemd features_check
 
-REQUIRED_DISTRO_FEATURES += "wayland"
+REQUIRED_DISTRO_FEATURES += "wayland pam"
 
 SYSTEMD_SERVICE:${PN} = "weston-touch-calibrator.service"
 


### PR DESCRIPTION
Declare the OE-Core layer dependency in layer.conf so tooling can validate the dependency already documented in the README.

Also require the pam distro feature for weston-touch-calibrator-service, matching its weston-init runtime dependency. This lets yocto-check-layer skip the recipe when pam is unavailable instead of failing world signature generation.
